### PR TITLE
Bug/service worker 404

### DIFF
--- a/fitness/app/public/_redirects
+++ b/fitness/app/public/_redirects
@@ -1,2 +1,1 @@
 /*	/index.html	200
-/dist/habitatfitness/service-worker.js /service-worker.js 200

--- a/fitness/app/public/_redirects
+++ b/fitness/app/public/_redirects
@@ -1,1 +1,2 @@
 /*	/index.html	200
+/dist/habitatfitness/service-worker.js /service-worker.js 200

--- a/fitness/app/public/_redirects
+++ b/fitness/app/public/_redirects
@@ -1,2 +1,1 @@
-/dist/habitatfitness/service-worker.js /service-worker.js 200
 /*	/index.html	200

--- a/fitness/app/public/_redirects
+++ b/fitness/app/public/_redirects
@@ -1,1 +1,2 @@
+/dist/habitatfitness/service-worker.js /service-worker.js 200
 /*	/index.html	200

--- a/fitness/app/src/registerServiceWorker.js
+++ b/fitness/app/src/registerServiceWorker.js
@@ -32,7 +32,7 @@ export default function register() {
     //window.addEventListener('load', () => {
       const swUrl = `/dist/habitatfitness/service-worker.js`;
 
-      if (!isLocalhost) {
+      if (isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.
         checkValidServiceWorker(swUrl);
 

--- a/fitness/app/src/registerServiceWorker.js
+++ b/fitness/app/src/registerServiceWorker.js
@@ -30,7 +30,7 @@ export default function register() {
     }
 
     //window.addEventListener('load', () => {
-      const swUrl = `service-worker.js`;
+      const swUrl = `/dist/habitatfitness/service-worker.js`;
 
       if (!isLocalhost) {
         // This is running on localhost. Lets check if a service worker still exists or not.


### PR DESCRIPTION
service-worker.js was always throwing 404 on local/Sitecore instances. Issue caused by Sitecore deployemnts to "dist/habitatfitness" but app was looking in Sitecore webroot for js file.

Now points to service worker in "dist/habitatfitness" folder and there is a redirect for Netlify to look in the root folder instead for the service worker.