### PR TITLE
Feature/9.1.1/graphql config updates disabled

### DIFF
--- a/fitness/server/Fitness.AppItems/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.GraphQL.config.disabled
+++ b/fitness/server/Fitness.AppItems/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.GraphQL.config.disabled
@@ -1,0 +1,36 @@
+﻿<!--
+  JSS Sitecore Configuration Patch File
+
+  This configuration file patches updates to the following 2 config file that are installed with JSS server side components:
+  - Sitecore.Services.GraphQL.config
+  - Sitecore.Services.GraphQL.Content.config
+-->
+<configuration xmlns:patch="http://www.sitecore.net/xmlconfig/" xmlns:role="http://www.sitecore.net/xmlconfig/role/">
+    <sitecore>
+        <api>
+            <GraphQL>
+                <defaults>
+                    <security>
+                        <systemService type="Sitecore.Services.GraphQL.Hosting.Security.GraphQLSecurity, Sitecore.Services.GraphQL">
+                            <requireAuthentication>false</requireAuthentication>
+                            <requireApiKey>true</requireApiKey>
+                        </systemService>
+                    </security>
+					<content>
+                        <schemaProviders>
+                            <systemContent type="Sitecore.Services.GraphQL.Content.ContentSchemaProvider, Sitecore.Services.GraphQL.Content">
+                                <mutations hint="raw:AddMutation">
+                                    <patch:delete />
+                                </mutations>
+                                <subscriptions hint="raw:AddSubscription">
+                                    <patch:delete />
+                                </subscriptions>
+                            </systemContent>
+                        </schemaProviders>
+                    </content>
+                </defaults>
+            </GraphQL>
+        </api>
+    </sitecore>
+</configuration>
+

--- a/fitness/server/Fitness.AppItems/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.GraphQL.config.disabled
+++ b/fitness/server/Fitness.AppItems/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.GraphQL.config.disabled
@@ -16,7 +16,7 @@
                             <requireApiKey>true</requireApiKey>
                         </systemService>
                     </security>
-					<content>
+					          <content>
                         <schemaProviders>
                             <systemContent type="Sitecore.Services.GraphQL.Content.ContentSchemaProvider, Sitecore.Services.GraphQL.Content">
                                 <mutations hint="raw:AddMutation">

--- a/fitness/server/Fitness.AppItems/Sitecore.HabitatHome.Fitness.AppItems.csproj
+++ b/fitness/server/Fitness.AppItems/Sitecore.HabitatHome.Fitness.AppItems.csproj
@@ -82,6 +82,7 @@
     <Content Include="App_Config\Include\Sitecore.HabitatHome.Fitness\Sitecore.HabitatHome.Fitness.Common.Serialization.config" />
     <Content Include="App_Config\Include\Sitecore.HabitatHome.Fitness\Sitecore.HabitatHome.Fitness.MarketingDefinitions.Serialization.config" />
     <Content Include="App_Config\Include\Unicorn\Unicorn.zSharedSecret.config" />
+    <Content Include="App_Config\Include\Sitecore.HabitatHome.Fitness\Sitecore.HabitatHome.Fitness.GraphQL.config.disabled" />
     <None Include="Web.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
Changes requested by Anastasiya

GraphQL config patches to:

- Allow GraphQL queries with API key (can use JSS API key)
- Remove "Mutations" and "Subscriptions" nodes from config