### PR TITLE
Renaming the xConnect model class to "Model" to play nicely with DEF …

### DIFF
--- a/fitness/server/Fitness.Collection.Model/ModelFactory.cs
+++ b/fitness/server/Fitness.Collection.Model/ModelFactory.cs
@@ -7,7 +7,7 @@ namespace Sitecore.HabitatHome.Fitness.Collection.Model
 {
     public static class ModelFactory
     {
-        public static XdbModel Instance { get; } = CreateModel();
+        public static XdbModel Model { get; } = CreateModel();
 
         public static XdbModel CreateModel()
         {

--- a/fitness/server/Fitness.Collection/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.Collection.config
+++ b/fitness/server/Fitness.Collection/App_Config/Include/Sitecore.HabitatHome.Fitness/Sitecore.HabitatHome.Fitness.Collection.config
@@ -6,7 +6,7 @@
           <!-- value of 'name' property must be unique -->
           <schema name="habitatfitness" type="Sitecore.XConnect.Client.Configuration.StaticModelConfiguration,Sitecore.XConnect.Client.Configuration" patch:after="schema[@name='collectionmodel']">
             <param desc="modeltype">Sitecore.HabitatHome.Fitness.Collection.Model.ModelFactory,Sitecore.HabitatHome.Fitness.Collection.Model</param>
-            <param desc="staticproperty">Instance</param>
+            <param desc="staticproperty">Model</param>
           </schema>
         </schemas>
       </runtime>

--- a/fitness/server/Fitness.Collection/XConnectClientFactory.cs
+++ b/fitness/server/Fitness.Collection/XConnectClientFactory.cs
@@ -65,7 +65,7 @@ namespace Sitecore.HabitatHome.Fitness.Collection
             collectionClient = new CollectionWebApiClient(new Uri(endpointUri, "odata/"), modifiers, certificateModifiers);
             searchClient = new SearchWebApiClient(new Uri(endpointUri, "odata/"), modifiers, certificateModifiers);
             configurationClient = new ConfigurationWebApiClient(new Uri(endpointUri, "configuration/"), modifiers, certificateModifiers);
-            cfg = new XConnectClientConfiguration(new XdbRuntimeModel(ModelFactory.Instance), collectionClient, searchClient, configurationClient, true);
+            cfg = new XConnectClientConfiguration(new XdbRuntimeModel(ModelFactory.Model), collectionClient, searchClient, configurationClient, true);
 
             await cfg.InitializeAsync();
             return new XConnectClient(cfg);


### PR DESCRIPTION
Renaming the xConnect model class to "Model" to play nicely with DEF framework to auto-create xConnect items.

Needed to update a few other files after the rename.